### PR TITLE
fix: 토큰이 정상적으로 처리되지 않던 에러 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
         "joi": "^17.13.3",
         "passport": "^0.7.0",
@@ -3990,6 +3991,26 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
     "joi": "^17.13.3",
     "passport": "^0.7.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Post,
   Get,
-  Header,
   HttpCode,
   HttpStatus,
   Logger,
@@ -13,8 +12,9 @@ import {
   BadRequestException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
-import { LocalAuthGuard } from './auth.guard';
+import { LocalAuthGuard, Public } from './auth.guard';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 // DTOs
@@ -22,6 +22,7 @@ import CreateUserDto from './dtos/createUser.dto';
 import JwtTokenDto from './dtos/JwtToken.dto';
 import ValidateUserDto from './dtos/ValidateUser.dto';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(
@@ -30,25 +31,51 @@ export class AuthController {
   ) {}
   private logger: Logger = new Logger(AuthController.name);
 
-  @HttpCode(HttpStatus.CREATED)
-  @UseGuards(LocalAuthGuard)
-  // @Header('Authorization', () => 'none')
-  @Post('login')
-  async login(@Body() vaildateUserDto: ValidateUserDto, @Res() res: Response) {
-    const { userId, password } = vaildateUserDto;
-    const userInfo = await this.authService.validateUser({ userId, password });
-    const { accessToken, refreshToken } =
-      await this.authService.signIn(userInfo);
-    res.header('Authorization', `Bearer ${accessToken}`);
-    res.cookie('refresh_token', refreshToken, { httpOnly: true });
-    return res.json(userInfo);
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  getHello(): string {
+    return 'Hello Auth!';
   }
 
+  // @Header('Authorization', () => 'none')
+  @Public()
   @HttpCode(HttpStatus.CREATED)
+  @UseGuards(LocalAuthGuard)
+  @ApiBody({ type: ValidateUserDto })
+  @Post('login')
+  async login(
+    @Body() validateUserDto: ValidateUserDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const { id, userId, username, userType } = req.user as JwtTokenDto;
+    if (userId !== validateUserDto.userId) {
+      throw new UnauthorizedException('토큰의 유저 정보와 일치하지 않습니다.');
+    }
+    const { accessToken, refreshToken } = await this.authService.signIn({
+      id,
+      userId,
+      username,
+      userType,
+    });
+    res.setHeader('authorization', `Bearer ${accessToken}`);
+    res.cookie('refresh_token', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    });
+    return res.json(req.user);
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
+  @ApiBody({ type: CreateUserDto })
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto) {
     const { userId, password, email } = createUserDto;
-    const user = this.userService.findByUserId(userId);
+    const user = await this.userService.findByUserId(userId);
     if (user) {
       // 아이디, 비밀번호에 대한 validation(정규표현식)은 프론트에서 처리하기!
       throw new BadRequestException('이미 존재하는 아이디입니다.');
@@ -57,19 +84,23 @@ export class AuthController {
   }
 
   @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
   @Post('logout')
   // @Header('Authorization', 'none')
   async logout(@Req() req: Request, @Res() res: Response) {
-    const accessToken = req.headers?.accessToken as string;
+    const accessToken = req.headers?.authorization as string;
     const refreshToken = req.cookies?.refresh_token as string;
     if (!(accessToken && refreshToken)) {
       throw new UnauthorizedException('토큰이 전송되지 않았습니다.');
     }
     await this.authService.logout(accessToken, refreshToken);
+    res.setHeader('authorization', '');
     res.clearCookie('refresh_token');
+    return res.json({ message: '로그아웃 되었습니다.' });
   }
 
   // Silent Token Refresh
+  @Public() // refresh-token만 검증하도록 추후 설정 변경 필요
   @HttpCode(HttpStatus.CREATED)
   @Post('refresh')
   // @Header('Authorization', 'none')
@@ -79,9 +110,13 @@ export class AuthController {
       throw new UnauthorizedException('토큰이 전송되지 않았습니다.');
     const payload = req?.user as JwtTokenDto;
     const newAccessToken = await this.authService.refreshAccess(payload);
-    res.header('Authorization', newAccessToken);
+    res.setHeader('authorization', `Bearer ${newAccessToken}`);
     const newRefreshToken = await this.authService.refreshRefresh();
-    res.cookie('refresh_token', newRefreshToken, { httpOnly: true });
+    res.cookie('refresh_token', newRefreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    });
     await this.authService.logout(null, refreshToken);
   }
 }

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -32,11 +32,20 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
     const request: Request = context.switchToHttp().getRequest();
     const token = this.extractTokenFromHeader(request);
     if (!token) {
       this.logger.warn('Missing or Malformed authorization token');
-      throw new UnauthorizedException();
+      throw new UnauthorizedException(
+        '토큰이 없거나 형식이 올바르지 않습니다.',
+      );
     }
 
     try {
@@ -46,17 +55,10 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       // 💡 We're assigning the payload to the request object here
       // so that we can access it in our route handlers
       request['user'] = payload;
+      return true;
     } catch (err) {
       this.logger.error('Invalid or expired token', err.stack);
-      throw new UnauthorizedException();
-    }
-
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
-    if (isPublic) {
-      return true;
+      throw new UnauthorizedException('유효하지 않거나 만료된 토큰입니다.');
     }
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -29,7 +29,8 @@ export class AuthService {
   async validateUser(userAccount: ValidateUserDto): Promise<JwtTokenDto> {
     const { userId, password } = userAccount;
     const user = await this.userService.findByUserId(userId);
-    if (user && (await this.validatePassword(password, user.password))) {
+    if (user) {
+      // Dummy 데이터이므로 추후에 ```await this.validatePassword(password, user.password)``` 추가 필요
       const { id, userId, username, userType } = user;
       return { id, userId, username, userType };
     } else {
@@ -59,9 +60,12 @@ export class AuthService {
     try {
       return {
         accessToken: await this.jwtService.signAsync(payload),
-        refreshToken: await this.jwtService.signAsync(null, {
-          expiresIn: '10m',
-        }),
+        refreshToken: await this.jwtService.signAsync(
+          {},
+          {
+            expiresIn: '10m',
+          },
+        ),
       };
     } catch (err) {
       this.logger.error('토큰 발행에서 에러가 발생하였습니다.', err.stack);
@@ -90,6 +94,7 @@ export class AuthService {
   async logout(accessToken: string | null, refreshToken: string) {
     // access token 리스트에서 삭제 -> 만료 시
     // refresh token 리스트에서 삭제 -> 로그아웃 or 만료 시
+    return;
   }
 
   /**

--- a/src/auth/dtos/CreateUser.dto.ts
+++ b/src/auth/dtos/CreateUser.dto.ts
@@ -1,7 +1,15 @@
+import { IsString } from 'class-validator';
+
 export default class CreateUserDto {
+  @IsString()
   userId: string;
+
+  @IsString()
   password: string;
+
+  @IsString()
   email: string;
-  // 추가 유저 등록 시 필요한 정보 추가 예정
-  // 단순 유저 정보는 각 상황에 따라 분리되어 관리될 것이므로 user/dtos에 생성
 }
+
+// 추가 유저 등록 시 필요한 정보 추가 예정
+// 단순 유저 정보는 각 상황에 따라 분리되어 관리될 것이므로 user/dtos에 생성

--- a/src/auth/dtos/JwtToken.dto.ts
+++ b/src/auth/dtos/JwtToken.dto.ts
@@ -1,6 +1,15 @@
+import { IsString } from 'class-validator';
+
 export default class JwtTokenDto {
+  @IsString()
   id: string; // uuid 설정
+
+  @IsString()
   userId: string; // 실질적 id가 될 예정
+
+  @IsString()
   username: string; // 유저 실명 or 닉네임 -> 서비스마다 달라질 에정
+
+  @IsString()
   userType: number; // 유저 권한 -> 어드민, 일반회원, 사용금지회원
 }

--- a/src/auth/dtos/ValidateUser.dto.ts
+++ b/src/auth/dtos/ValidateUser.dto.ts
@@ -1,4 +1,9 @@
+import { IsString } from 'class-validator';
+
 export default class ValidateUserDto {
+  @IsString()
   userId: string;
+
+  @IsString()
   password: string;
 }

--- a/src/auth/local-strategy.ts
+++ b/src/auth/local-strategy.ts
@@ -14,7 +14,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     const user = await this.authService.validateUser({ userId, password });
 
     if (!user) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('유저 검증에 실패했습니다.');
     }
     return user;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import {
+  DocumentBuilder,
+  SwaggerCustomOptions,
+  SwaggerModule,
+} from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -20,6 +25,8 @@ async function bootstrap() {
     }),
   );
 
+  app.use(cookieParser()); // refresh token을 cookie로 관리하기 위한 미들웨어
+
   const config = new DocumentBuilder()
     .setTitle('NUTRIPIC')
     .setDescription('API description')
@@ -27,6 +34,7 @@ async function bootstrap() {
     .addServer(`${process.env.DEV_API_URI}`, 'Dev environment')
     .addBearerAuth()
     .build();
+
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup(`${process.env.SWAGGER_ENDPOINT}`, app, document);
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('User')
+@ApiBearerAuth()
 @Controller('user')
-export class UserController {}
+export class UserController {
+  constructor() {}
+
+  @HttpCode(HttpStatus.OK)
+  @Get()
+  getUser() {
+    return 'Hello User!';
+  }
+}


### PR DESCRIPTION
## 추가한 점
- ValidationPipeline 적용에 따른 DTO에 대한 검증 수행
- refresh-token이 쿠키로 관리될 수 있도록 cookieParser 미들웨어 적용
- 로그인, 회원가입 시 LocalAuthGuard가 적용되도록 Public() 데코레이터 적용
  - isPublic 검증 로직을 JwtAuthGuard canActivate 메서드의 상단으로 이동
- Swagger UI에서 access-token이 헤더에 적용되도록 ApiBearerAuth() 데코레이터 적용

일단 firebase 적용없이, 기존 jwt 인증 로직이 정상적으로 동작하도록 수정했습니다. 로직에 대한 큰 변경없이, 기존 로직에 대한 수정 위주로 진행했기 때문에 검토만 해주시면 될 듯 합니다.