### PR TITLE
fix: storage dto 오류 수정

### DIFF
--- a/src/storage/dto/createFood.dto.ts
+++ b/src/storage/dto/createFood.dto.ts
@@ -9,11 +9,6 @@ import {
 } from 'class-validator';
 
 export class CreateFoodDto {
-  @ApiProperty({ description: '식재료 id - 자동 생성 (입력 필요 없음)' })
-  @IsString()
-  @IsOptional()
-  id?: number;
-
   @ApiProperty({ description: 'fridge/freezer/room' })
   @IsString()
   @IsNotEmpty()

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -12,7 +12,6 @@ import {
 import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { FirebaseAuthGuard } from 'src/auth/auth.guard';
 import { User } from 'src/utils/decorator/user.decorator';
-import { FoodDto } from './dto/food.dto';
 import { StorageService } from './storage.service';
 import { DeleteFoodDto } from './dto/deleteFood.dto';
 import { Food } from '@prisma/client';
@@ -29,20 +28,22 @@ export class StorageController {
   @UseGuards(FirebaseAuthGuard)
   @Get()
   @HttpCode(HttpStatus.OK)
-  getFood(@User() uid: string): Promise<{ storage: string; foods: Food[] }[]> {
-    return this.storageService.getStorageByUser(uid);
+  getFood(
+    @User() userId: string
+  ): Promise<{ storage: string; foods: Food[] }[]> {
+    return this.storageService.getStorageByUser(userId);
   }
 
   //식재료 추가하기
-  @ApiBody({ type: [FoodDto], description: '추가할 식재료 정보 (배열)' })
+  @ApiBody({ type: [CreateFoodDto], description: '추가할 식재료 정보 (배열)' })
   @UseGuards(FirebaseAuthGuard)
   @Post('/add')
   @HttpCode(HttpStatus.CREATED)
   addFood(
-    @User() uid: string,
+    @User() userId: string,
     @Body() foods: CreateFoodDto[]
   ): Promise<Food[]> {
-    return this.storageService.createFoods(uid, foods);
+    return this.storageService.createFoods(userId, foods);
   }
 
   //식재료 삭제하기
@@ -50,8 +51,11 @@ export class StorageController {
   @UseGuards(FirebaseAuthGuard)
   @Delete('/delete')
   @HttpCode(HttpStatus.OK)
-  deleteFood(@User() uid: string, @Body() food: DeleteFoodDto): Promise<Food> {
-    return this.storageService.deleteFood(uid, food.id);
+  deleteFood(
+    @User() userId: string,
+    @Body() food: DeleteFoodDto
+  ): Promise<Food> {
+    return this.storageService.deleteFood(userId, food.id);
   }
 
   //식재료 정보 수정
@@ -59,7 +63,10 @@ export class StorageController {
   @UseGuards(FirebaseAuthGuard)
   @Put('/update')
   @HttpCode(HttpStatus.OK)
-  updateFood(@User() uid: string, @Body() food: UpdateFoodDto): Promise<Food> {
-    return this.storageService.updateFoodInfo(uid, food);
+  updateFood(
+    @User() userId: string,
+    @Body() food: UpdateFoodDto
+  ): Promise<Food> {
+    return this.storageService.updateFoodInfo(userId, food);
   }
 }

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { Food, StorageType } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { FoodDto } from './dto/food.dto';
 import { UpdateFoodDto } from './dto/updateFood.dto';
+import { CreateFoodDto } from './dto/createFood.dto';
 
 @Injectable()
 export class StorageRepository {
@@ -18,9 +18,10 @@ export class StorageRepository {
     });
   }
 
-  async createFoods(foods: FoodDto[]): Promise<Food[]> {
+  async createFoods(userId: string, foods: CreateFoodDto[]): Promise<Food[]> {
+    const createFoodData = foods.map((food) => ({ ...food, userId }));
     return this.prisma.food.createManyAndReturn({
-      data: foods,
+      data: createFoodData,
     });
   }
 

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -12,12 +12,7 @@ export class StorageService {
   async createFoods(userId: string, Foods: CreateFoodDto[]): Promise<Food[]> {
     //TODO: 식재료 유통기한 정보 추가
 
-    const FoodsToAdd = Foods.map((food) => ({
-      userId,
-      ...food,
-    }));
-
-    return this.storageRepository.createFoods(FoodsToAdd);
+    return this.storageRepository.createFoods(userId, Foods);
   }
 
   //내 식재료 가져오기


### PR DESCRIPTION
식재료 db 수정하면서 dto를 수정하지 않아 createFood에 문제가 있었습니다. 
스웨거 `/get-api-docs`에 storage api와 dto 설명을 간략하게 적어두었으니 참고해주세요

식재료 추가 `/storage/add` 입력 예시
![image](https://github.com/user-attachments/assets/39d004a0-665d-47de-896d-9a49e27eb75a)

식재료 정보 수정 `/storage/update` 입력 예시
![image](https://github.com/user-attachments/assets/5592cf7d-ed10-43d4-be9b-88019014811f)
