### PR TITLE
fix: 다이어리 기능 수정 및 변경

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,15 +120,10 @@ model Diary{
   body String
   date DateTime @default(now()) @db.Timestamp
   url String
+  mealTime Int // 1: 아침 2: 점심 3: 저녁
   isDeleted Boolean @default(false)
   createdAt DateTime @default(now()) @db.Timestamp
   deletedAt DateTime? @db.Timestamp
 
   @@map("diary")
-} // recipe와도 참조관계를 설정하여 어떤 레시피에 따라 요리를 했는지 다이어리에 표시하는 것도 좋을 것 같습니다!
-
-// model DiaryImage{
-//   url String @id
-//   diary Diary @relation(fields: [diaryId], references: [id])
-//   diaryId Int @unique
-// }
+}

--- a/src/diary/diary.repository.ts
+++ b/src/diary/diary.repository.ts
@@ -24,7 +24,8 @@ export class DiaryRepository {
           where: {
             userId: userId,
             date: {
-              equals: new Date(year, month, day),
+              gte: new Date(year, month, day, 9),
+              lt: new Date(year, month, day + 1, 9), // 해당 년월일에 생성된 다이어리
             },
             isDeleted: false,
           },
@@ -33,8 +34,8 @@ export class DiaryRepository {
           where: {
             userId: userId,
             date: {
-              gte: new Date(year, month, 1),
-              lt: new Date(year, month + 1, 1), // 해당 년월에 생성된 다이어리
+              gte: new Date(year, month, 1, 9),
+              lt: new Date(year, month + 1, 1, 9), // 해당 년월에 생성된 다이어리
             },
             isDeleted: false,
           },
@@ -93,3 +94,4 @@ export class DiaryRepository {
     });
   }
 }
+

--- a/src/diary/diary.repository.ts
+++ b/src/diary/diary.repository.ts
@@ -46,6 +46,7 @@ export class DiaryRepository {
     userId: string,
     body: string,
     url: string,
+    mealTime: number,
     date: Date
   ): Promise<Diary> {
     return this.prisma.diary.create({
@@ -53,12 +54,13 @@ export class DiaryRepository {
         userId: userId,
         body: body,
         url: url,
+        mealTime: mealTime,
         date: date,
       },
     });
   }
 
-  async updateDiary(diaryId: number, body: string, date: Date): Promise<Diary> {
+  async updateDiary(diaryId: number, body: string, mealTime: number, date: Date): Promise<Diary> {
     return await this.prisma.diary.update({
       where: {
         id: diaryId,
@@ -66,6 +68,7 @@ export class DiaryRepository {
       data: {
         body: body,
         date: date,
+        mealTime: mealTime,
       },
     });
   }

--- a/src/diary/diary.service.ts
+++ b/src/diary/diary.service.ts
@@ -64,6 +64,7 @@ export class DiaryService {
       ({
         id: diary.id,
         url: diary.url,
+        mealTime: diary.mealTime,
         date: diary.date,
       })
     );
@@ -84,6 +85,7 @@ export class DiaryService {
       id: diary.id,
       body: diary.body,
       url: diary.url,
+      mealTime: diary.mealTime,
       date: diary.date,
     };
   }
@@ -92,11 +94,12 @@ export class DiaryService {
     userId: string,
     createDiaryReqDto: CreateDiaryReqDto
   ): Promise<void> {
-    const { body, date, url } = createDiaryReqDto;
+    const { body, date, url, mealTime } = createDiaryReqDto;
     const diary = await this.diaryRepository.createDiary(
       userId,
       body,
       url,
+      mealTime,
       new Date(date)
     );
     if (!diary) throw new BadGatewayException('다이어리 생성에 실패했습니다.');
@@ -111,11 +114,12 @@ export class DiaryService {
     if (!diary)
       throw new NotFoundException('해당 ID의 다이어리가 존재하지 않습니다.');
 
-    const { body, date } = updateDiaryReqDto;
+    const { body, date, mealTime } = updateDiaryReqDto;
 
     const updatedDiary = await this.diaryRepository.updateDiary(
       diaryId,
       body,
+      mealTime,
       new Date(date)
     );
 
@@ -145,6 +149,7 @@ export class DiaryService {
       body: diary.body,
       url: diary.url,
       date: diary.date,
+      mealTime: diary.mealTime,
     };
   }
 }

--- a/src/diary/diary.service.ts
+++ b/src/diary/diary.service.ts
@@ -60,13 +60,13 @@ export class DiaryService {
       targetMonth,
       day
     );
-    return diaries.map((diary) => ({
-      id: diary.id,
-      url: diary.url,
-      date: diary.date,
-    }));
-
-    return;
+    return diaries.map((diary) => 
+      ({
+        id: diary.id,
+        url: diary.url,
+        date: diary.date,
+      })
+    );
   }
 
   async getDiaryById(
@@ -148,3 +148,4 @@ export class DiaryService {
     };
   }
 }
+

--- a/src/diary/dto/createDiary.dto.ts
+++ b/src/diary/dto/createDiary.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class CreateDiaryReqDto {
   @ApiProperty({
@@ -26,4 +26,12 @@ export class CreateDiaryReqDto {
   @IsString()
   @IsNotEmpty()
   url: string;
+
+  @ApiProperty({
+    description: '다이어리 등록 식사 시간 (1: 아침 2: 점심 3: 저녁)',
+    example: 1
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  mealTime: number;
 }

--- a/src/diary/dto/getDailyDiary.dto.ts
+++ b/src/diary/dto/getDailyDiary.dto.ts
@@ -1,4 +1,5 @@
-import { IsDateString, IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class GetDailyDiaryResDto {
   @IsNumber()
@@ -9,4 +10,12 @@ export class GetDailyDiaryResDto {
 
   @IsDateString()
   date: Date | string;
+
+  @ApiProperty({
+    description: '다이어리 등록 식사 시간 (1: 아침 2: 점심 3: 저녁)',
+      example: 1
+    })
+    @IsNumber()
+    @IsNotEmpty()
+    mealTime: number;
 }

--- a/src/diary/dto/getDiary.dto.ts
+++ b/src/diary/dto/getDiary.dto.ts
@@ -26,4 +26,12 @@ export class GetDiaryResDto {
   @IsDate()
   @IsNotEmpty()
   date: Date;
+
+  @ApiProperty({
+    description: '다이어리 등록 식사 시간 (1: 아침 2: 점심 3: 저녁)',
+    example: 1
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  mealTime: number;
 }

--- a/src/diary/dto/updateDiary.dto.ts
+++ b/src/diary/dto/updateDiary.dto.ts
@@ -20,6 +20,14 @@ export class UpdateDiaryReqDto {
   })
   @IsDateString()
   date: Date | string;
+
+  @ApiProperty({
+    description: '다이어리 등록 식사 시간 (1: 아침 2: 점심 3: 저녁)',
+    example: 1
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  mealTime: number;
 }
 
 export class UpdateDiaryResDto {
@@ -49,4 +57,12 @@ export class UpdateDiaryResDto {
   @IsDate()
   @IsNotEmpty()
   date: Date;
+
+  @ApiProperty({
+    description: '다이어리 등록 식사 시간 (1: 아침 2: 점심 3: 저녁)',
+    example: 1
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  mealTime: number;
 }


### PR DESCRIPTION
**수정한 점**
- 클라이언트에서 넘겨준 값을 그대로 DB에 저장할 경우 timezone 변환 없이 plain하게 저장되지만, 이를 `new Date()`로 생성한 날짜 객체와 비교할 경우 정상적인 값 비교가 이루어지지 않는 것을 확인
  - 클라이언트에서 넘겨주는 값이 KST(UTC +9)인 것을 감안하여 비교를 위해 넣어주는 쿼리문 날짜 인자에 +9를 추가
  - 클라이언트에서 넘겨주는 값은 변경될 필요 없습니다.

- 다이어리 등록, 수정 시 식사시간(`mealTime`)을 추가할 수 있도록하였으며, 일자 및 개별 다이어리 시 각각의 식사시간도 포함시켜 반환
  - 1: 아침, 2: 점심, 3: 저녁, 4: 간식, 5: 기타
  - 0이 아닌 정수값으로 넘겨주는 것이 추후 로직 및 서비스 확장에 용이할 것으로 생각됩니다. 위의 컨벤션은 임의로 정한 것이고, 필요에 따라 수정해도 됩니다. DB에서 제한되어 있는 값은 없기 때문에 클라이언트에엇 자유롭게 정수값으로만 넘어오면 됩니다.