### PR TITLE
Feature/image to food 수정사항

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,8 @@ model FoodInfo {
   class1    String @db.VarChar(255) //대분류
   class2    String @db.VarChar(255) @default("기타") //중분류
   storageType  StorageType @map("storage_type")
-  expireDate   Int?   @map("expire_date") //일 단위
+  expireDate   Int?   @map("expire_date") //일 
+  icon         String @db.VarChar(255) @default("null") //아이콘 분류
 
   @@map("food_info")
 }

--- a/src/image-to-food/imageToFood.controller.ts
+++ b/src/image-to-food/imageToFood.controller.ts
@@ -1,5 +1,8 @@
 import {
   Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
   Post,
   UploadedFile,
   UseInterceptors,
@@ -8,16 +11,54 @@ import { ImageToFoodService } from './imageToFood.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Public } from 'src/auth/auth.guard';
 import { CreateFoodDto } from 'src/storage/dto/createFood.dto';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('Image To Food Analysis')
+@ApiBearerAuth()
 @Controller('image-to-food')
 export class ImageToFoodController {
   constructor(private readonly imageToFoodService: ImageToFoodService) {}
+  private logger: Logger = new Logger(ImageToFoodController.name);
 
+  @ApiOperation({ summary: '이미지를 분석하여 식재료 리스트 추출' })
+  @ApiOkResponse({
+    type: CreateFoodDto,
+    isArray: true,
+    description: '식재료 리스트, storageType으로 분류',
+    example: [
+      [
+        {
+          name: '양파',
+          storageType: 'fridge',
+        },
+      ],
+      [
+        {
+          name: '당근',
+          storageType: 'freezer',
+        },
+      ],
+      [
+        {
+          name: '닭고기',
+          storageType: 'room',
+        },
+      ],
+    ],
+  })
   @Post('analyze')
+  @HttpCode(HttpStatus.OK)
   @UseInterceptors(FileInterceptor('image'))
   async analyzeImage(
     @UploadedFile() image: Express.Multer.File
   ): Promise<CreateFoodDto[][] | { message: string }> {
+    this.logger.log(`Analyze image`);
     if (!image) {
       return {
         message: 'No image uploaded',

--- a/src/image-to-food/imageToFood.controller.ts
+++ b/src/image-to-food/imageToFood.controller.ts
@@ -4,16 +4,15 @@ import {
   HttpStatus,
   Logger,
   Post,
-  UploadedFile,
+  UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common';
 import { ImageToFoodService } from './imageToFood.service';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FilesInterceptor } from '@nestjs/platform-express';
 import { Public } from 'src/auth/auth.guard';
 import { CreateFoodDto } from 'src/storage/dto/createFood.dto';
 import {
   ApiBearerAuth,
-  ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -54,17 +53,17 @@ export class ImageToFoodController {
   })
   @Post('analyze')
   @HttpCode(HttpStatus.OK)
-  @UseInterceptors(FileInterceptor('image'))
+  @UseInterceptors(FilesInterceptor('image', 5))
   async analyzeImage(
-    @UploadedFile() image: Express.Multer.File
+    @UploadedFiles() images: Array<Express.Multer.File>
   ): Promise<CreateFoodDto[][] | { message: string }> {
     this.logger.log(`Analyze image`);
-    if (!image) {
+    if (!images) {
       return {
         message: 'No image uploaded',
       };
     }
 
-    return this.imageToFoodService.analyzeImage(image);
+    return this.imageToFoodService.analyzeImage(images);
   }
 }

--- a/src/image-to-food/imageToFood.repository.ts
+++ b/src/image-to-food/imageToFood.repository.ts
@@ -27,7 +27,6 @@ export class ImageToFoodRepository {
         class2: food.class2,
         addedDate: currentDate.toISOString(),
         expireDate: expireDate.toISOString(),
-        expired: false,
       });
     });
 
@@ -41,7 +40,6 @@ export class ImageToFoodRepository {
           class1: '기타',
           class2: '기타',
           addedDate: new Date().toISOString(),
-          expired: false,
         };
       }
     });

--- a/src/image-to-food/imageToFood.repository.ts
+++ b/src/image-to-food/imageToFood.repository.ts
@@ -18,9 +18,8 @@ export class ImageToFoodRepository {
     const foodInfoMap = new Map<string, CreateFoodDto>();
     (await foodInfo).forEach(async (food) => {
       const currentDate = new Date();
-      const expireDate = new Date(
-        currentDate.setDate(currentDate.getDate() + food.expireDate)
-      );
+      const expireDate = new Date(currentDate);
+      expireDate.setDate(expireDate.getDate() + food.expireDate);
       foodInfoMap.set(food.class2, {
         name: food.class2,
         storageType: food.storageType,

--- a/src/image-to-food/imageToFood.service.ts
+++ b/src/image-to-food/imageToFood.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { ImageToFoodRepository } from './imageToFood.repository';
 import { CreateFoodDto } from 'src/storage/dto/createFood.dto';
+import { ChatCompletionContentPart } from 'openai/resources';
 
 @Injectable()
 export class ImageToFoodService {
@@ -16,31 +17,38 @@ export class ImageToFoodService {
     });
   }
 
-  async analyzeImage(image: Express.Multer.File): Promise<CreateFoodDto[][]> {
+  async analyzeImage(
+    images: Express.Multer.File[]
+  ): Promise<CreateFoodDto[][]> {
     try {
-      const base64Image = image.buffer.toString('base64');
+      const base64Images = images.map((image) =>
+        image.buffer.toString('base64')
+      );
+
+      const content: ChatCompletionContentPart[] = [
+        {
+          type: 'text',
+          text: "What's in this image?",
+        },
+        {
+          type: 'text',
+          text: '모든 사진에 있는 식재료가 뭐가 있는지 하나의 리스트 형식으로 말해줘. 다른 텍스트는 필요없어.',
+        },
+      ];
+
+      base64Images.forEach((base64Image) => {
+        content.push({
+          type: 'image_url',
+          image_url: { url: `data:image/jpeg;base64,${base64Image}` },
+        });
+      });
 
       const completion = await this.openAi.chat.completions.create({
         model: 'gpt-4o',
         messages: [
           {
             role: 'user',
-            content: [
-              {
-                type: 'text',
-                text: "What's in this image?",
-              },
-              {
-                type: 'text',
-                text: '이 안에 있는 식재료가 뭐가 있는지 리스트 형식으로 말해줘. 다른 텍스트는 필요없어.',
-              },
-              {
-                type: 'image_url',
-                image_url: {
-                  url: `data:image/jpeg;base64,${base64Image}`,
-                },
-              },
-            ],
+            content: content,
           },
         ],
         max_tokens: 300,
@@ -52,8 +60,9 @@ export class ImageToFoodService {
       const food_list = response_data
         .split('\n')
         .map((food) => food.replace('- ', ''));
-      //ex: ['감자', '토마토', '당근']
+      // ex: ['감자', '토마토', '당근']
 
+      console.log(response_data);
       const foodInfo =
         await this.imageToFoodRepository.matchFoodInfo(food_list);
       const foodInfoByStorage = [[], [], []];

--- a/src/image-to-food/imageToFood.service.ts
+++ b/src/image-to-food/imageToFood.service.ts
@@ -62,7 +62,6 @@ export class ImageToFoodService {
         .map((food) => food.replace('- ', ''));
       // ex: ['감자', '토마토', '당근']
 
-      console.log(response_data);
       const foodInfo =
         await this.imageToFoodRepository.matchFoodInfo(food_list);
       const foodInfoByStorage = [[], [], []];

--- a/src/storage/dto/createFood.dto.ts
+++ b/src/storage/dto/createFood.dto.ts
@@ -55,13 +55,4 @@ export class CreateFoodDto {
   @IsDateString()
   @IsOptional() //TODO: empty? 기본 값 논의
   expireDate?: string | Date;
-
-  @ApiProperty({
-    description: '유통기한 지남 여부',
-    example: false,
-    default: false,
-  })
-  @IsBoolean()
-  @IsOptional() //기본값: false (유통기한 지나지 않음)
-  expired?: boolean;
 }

--- a/src/storage/dto/deleteFood.dto.ts
+++ b/src/storage/dto/deleteFood.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber } from 'class-validator';
 
 export class DeleteFoodDto {
-  @ApiProperty({ description: '식재료 id' })
-  @IsNumber()
+  @ApiProperty({ description: '삭제할 식재료 id 리스트' })
+  @IsArray()
   @IsNotEmpty()
-  id: number[];
+  @IsNumber({}, { each: true })
+  foodIds: number[];
 }

--- a/src/storage/dto/food.dto.ts
+++ b/src/storage/dto/food.dto.ts
@@ -4,6 +4,7 @@ import {
   IsBoolean,
   IsDateString,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
 } from 'class-validator';
@@ -72,10 +73,10 @@ export class FoodDto {
   expireDate?: string | Date;
 
   @ApiProperty({
-    description: '유통기한 지남 여부',
-    example: false,
+    description: '유통기한 임박 일수',
+    example: 3,
   })
-  @IsBoolean()
-  @IsOptional() //기본값: false (유통기한 지나지 않음)
-  expired?: boolean;
+  @IsNumber()
+  @IsOptional()
+  daysTilExpire?: number = null;
 }

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -25,6 +25,7 @@ import { StorageService } from './storage.service';
 import { UpdateFoodDto } from './dto/updateFood.dto';
 import { CreateFoodDto } from './dto/createFood.dto';
 import { FoodDto } from './dto/food.dto';
+import { DeleteFoodDto } from './dto/deleteFood.dto';
 
 @ApiTags('Storage')
 @ApiBearerAuth()
@@ -96,10 +97,10 @@ export class StorageController {
   @HttpCode(HttpStatus.OK)
   deleteFood(
     @User() userId: string,
-    @Body() foodIds: number[]
+    @Body() food: DeleteFoodDto
   ): Promise<number> {
-    this.logger.log(`Delete food`);
-    return this.storageService.deleteFood(userId, foodIds);
+    this.logger.log(`Delete food ${food.foodIds}`);
+    return this.storageService.deleteFood(userId, food.foodIds);
   }
 
   @ApiOperation({ summary: '식재료 정보 수정' })

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -9,14 +9,35 @@ import { FoodDto } from './dto/food.dto';
 export class StorageRepository {
   constructor(private prisma: PrismaService) {}
 
+  calculateDaysTilExpire(foods: FoodDto[]): FoodDto[] {
+    const currentDate = new Date();
+    const currentDateZero = new Date(currentDate.setUTCHours(0, 0, 0, 0));
+
+    return foods.map((food) => {
+      if (food.expireDate === null) {
+        return { ...food, daysTilExpire: null };
+      } //유통기한 만료일이 없다면 daysTilExpire = null
+      const expireDate = new Date(food.expireDate);
+
+      const daysTilExpire = Math.ceil(
+        (new Date(expireDate.setUTCHours(0, 0, 0, 0)).getTime() -
+          currentDateZero.getTime()) /
+          (1000 * 60 * 60 * 24)
+      );
+
+      return { ...food, daysTilExpire };
+    });
+  }
+
   //Storage에 저장된 식재료 모두 찾기
   async findFoodByStorage(
     userId: string,
     storageType: StorageType
   ): Promise<FoodDto[]> {
-    return this.prisma.food.findMany({
+    const foodsInStorage = await this.prisma.food.findMany({
       where: { userId, storageType },
     });
+    return this.calculateDaysTilExpire(foodsInStorage);
   }
 
   async createFoods(
@@ -24,27 +45,32 @@ export class StorageRepository {
     foods: CreateFoodDto[]
   ): Promise<FoodDto[]> {
     const createFoodData = foods.map((food) => ({ ...food, userId }));
-    return this.prisma.food.createManyAndReturn({
+    const foodsCreated = await this.prisma.food.createManyAndReturn({
       data: createFoodData,
     });
+    return this.calculateDaysTilExpire(foodsCreated);
   }
 
   async findByFoodId(id: number): Promise<FoodDto> {
-    return this.prisma.food.findUnique({
+    const foodFound = await this.prisma.food.findUnique({
       where: { id },
     });
+    return this.calculateDaysTilExpire([foodFound])[0];
   }
 
   async findFoodsWithOwner(
     userId: string,
     foodIds: number[]
   ): Promise<FoodDto[]> {
-    return this.prisma.food.findMany({
+    console.log(foodIds, userId);
+    const foodsFound = await this.prisma.food.findMany({
       where: { id: { in: foodIds }, userId: userId },
     });
+    return this.calculateDaysTilExpire(foodsFound);
   }
 
   async deleteManyFoods(foodIds: number[]): Promise<number> {
+    console.log(foodIds);
     const deleteCount = await this.prisma.food.deleteMany({
       where: { id: { in: foodIds } },
     });
@@ -52,11 +78,18 @@ export class StorageRepository {
   }
 
   async updateFoodInfo(foodInfo: UpdateFoodDto): Promise<FoodDto> {
-    return this.prisma.food.update({
+    const foodUpdated = await this.prisma.food.update({
       where: { id: foodInfo.id },
       data: {
-        ...foodInfo,
+        storageType: foodInfo.storageType,
+        name: foodInfo.name,
+        class1: foodInfo.class1,
+        class2: foodInfo.class2,
+        icon: foodInfo.icon,
+        addedDate: foodInfo.addedDate,
+        expireDate: foodInfo.expireDate,
       },
     });
+    return this.calculateDaysTilExpire([foodUpdated])[0];
   }
 }


### PR DESCRIPTION
### image-to-food 수정사항
1. `image-to-food/analyze` 이미지 업로드 장수 수정
2. food_info 테이블에 icon 컬럼 추가
3. 식재료 정보에 유통기한 임박 일수 추가
4. 기존 로직 수정

**image-to-food 다중 이미지 업로드**
이전에 이미지 한장만 받는걸 수정해 최대 5장까지 업로드 가능하도록 수정했습니다.
form-data file형식으로 받으며 모든 파일의 key는 image입니다.
![image](https://github.com/user-attachments/assets/0eb331a5-cc73-41ae-9dcb-cc6f3e24c962)

**food_info 테이블 수정**
icon 컬럼을 추가해 추후 디자인 팀이 제작한 아이콘 이름을 지정할 예정입니다. 

**식재료 정보에 유통기한 임박 일수 추가**
foodDto에 있던 expired (boolean) 필드를 제거하고 daysTilExpire (number) 필드를 추가했습니다.
식재료 정보를 불러올때 현재 날짜와 유통기한을 비교해 남은 유통기한 일수를 계산합니다.
expireDate 값이 null일 경우, daysTilExpire도 null이 됩니다.
![image](https://github.com/user-attachments/assets/6759ed30-d8f6-466f-bd1d-f72f9da3f050)


**기존 로직 수정**
daysTilExpire이 추가됨에 따라 foodDto를 사용하는 storage service, repository 메서드를 수정했습니다.