### PR TITLE
Fix/foodStorage 최근 삭제 식재료 조회 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "iostream": "cpp"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Food {
   addedDate    DateTime     @default(now()) @map("added_date")
   expireDate   DateTime?                    @map("expire_date")
   expired      Boolean      @default(false)
+  deletedDate  DateTime?    @map("deleted_date")
 
   @@map("food")
 }

--- a/src/recipe/recipe.repository.ts
+++ b/src/recipe/recipe.repository.ts
@@ -14,7 +14,7 @@ export class RecipeRepository {
     const foodList = await this.prisma.food.findMany({
       where: { userId },
       select: { name: true },
-    });
+    }); //TODO: 삭제하고 recommendedRecipe의 raw query에 join 추가? 쿼리 두번보단 join 추가 쿼리 비교하기 아마 후자가 빠를듯
 
     return foodList.map((food) => food.name);
   }

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -115,6 +115,19 @@ export class StorageController {
     return this.storageService.deleteFood(userId, food.foodIds);
   }
 
+  @ApiOperation({ summary: '최근 사용한 식재료 가져오기' })
+  @ApiOkResponse({
+    type: FoodDto,
+    isArray: true,
+    description: '최근 사용한 식재료 목록 반환',
+  })
+  @Get('/recently-used')
+  @HttpCode(HttpStatus.OK)
+  recentlyUsedFood(@User() userId: string): Promise<FoodDto[]> {
+    this.logger.log(`Get recently used food`);
+    return this.storageService.getRecentlyUsedFoods(userId);
+  }
+
   @ApiOperation({ summary: '식재료 정보 수정' })
   @ApiBody({
     type: UpdateFoodDto,

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -82,7 +82,6 @@ export class StorageRepository {
     userId: string,
     foodIds: number[]
   ): Promise<FoodDto[]> {
-    console.log(foodIds, userId);
     const foodsFound = await this.prisma.food.findMany({
       where: { id: { in: foodIds }, userId: userId },
     });
@@ -90,11 +89,20 @@ export class StorageRepository {
   }
 
   async deleteManyFoods(foodIds: number[]): Promise<number> {
-    console.log(foodIds);
-    const deleteCount = await this.prisma.food.deleteMany({
+    const deleteCount = await this.prisma.food.updateMany({
       where: { id: { in: foodIds } },
+      data: { deletedAt: new Date() },
     });
     return deleteCount.count;
+  }
+
+  async findDeletedFoods(userId: string): Promise<FoodDto[]> {
+    const deletedFoods = await this.prisma.food.findMany({
+      take: 10,
+      orderBy: { deletedAt: 'desc' },
+      where: { userId, deletedAt: { not: null } },
+    });
+    return deletedFoods;
   }
 
   async updateFoodInfo(foodInfo: UpdateFoodDto): Promise<FoodDto> {

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -36,7 +36,7 @@ export class StorageRepository {
     storageType: StorageType
   ): Promise<FoodDto[]> {
     const foodsInStorage = await this.prisma.food.findMany({
-      where: { userId, storageType },
+      where: { userId, storageType, deletedDate: null },
     });
     return this.calculateDaysTilExpire(foodsInStorage);
   }
@@ -91,7 +91,7 @@ export class StorageRepository {
   async deleteManyFoods(foodIds: number[]): Promise<number> {
     const deleteCount = await this.prisma.food.updateMany({
       where: { id: { in: foodIds } },
-      data: { deletedAt: new Date() },
+      data: { deletedDate: new Date() },
     });
     return deleteCount.count;
   }
@@ -99,8 +99,8 @@ export class StorageRepository {
   async findDeletedFoods(userId: string): Promise<FoodDto[]> {
     const deletedFoods = await this.prisma.food.findMany({
       take: 10,
-      orderBy: { deletedAt: 'desc' },
-      where: { userId, deletedAt: { not: null } },
+      orderBy: { deletedDate: 'desc' },
+      where: { userId, deletedDate: { not: null } },
     });
     return deletedFoods;
   }

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -59,6 +59,10 @@ export class StorageService {
     return deleteCount;
   }
 
+  async getRecentlyUsedFoods(userId: string): Promise<FoodDto[]> {
+    return this.storageRepository.findDeletedFoods(userId);
+  }
+
   //식재료 정보 수정
   async updateFoodInfo(
     userId: string,


### PR DESCRIPTION
최근 사용 (최근 삭제) 식재료 조회 기능을 추가했습니다.
기존 식재료 삭제 시 hard delete 하던 부분을 soft delete로 변경하고, /storage/recently-used로 최근 삭제한 식재료 최대 10개를 조회하는 기능을 추가했습니다.
이에 따라 Food 테이블에 DeletedDate 컬럼을 추가했습니다.