### PR TITLE
최근 사용 식재료 수정, 레시피 정보에 isFavorite 추가

### DIFF
--- a/src/recipe/dto/recipe.dto.ts
+++ b/src/recipe/dto/recipe.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { ingredientDto } from './ingredient.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -59,4 +65,12 @@ export class RecipeDto {
   @IsNumber()
   @IsNotEmpty()
   cookingTime: number;
+
+  @ApiProperty({
+    description: '레시피 북마크 여부',
+    example: 'true',
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isFavorite: boolean = false;
 }

--- a/src/recipe/dto/recipe.dto.ts
+++ b/src/recipe/dto/recipe.dto.ts
@@ -71,6 +71,6 @@ export class RecipeDto {
     example: 'true',
   })
   @IsBoolean()
-  @IsNotEmpty()
-  isFavorite: boolean = false;
+  @IsOptional()
+  isFavorite?: boolean = false;
 }

--- a/src/recipe/dto/recipePreview.dto.ts
+++ b/src/recipe/dto/recipePreview.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { ingredientDto } from './ingredient.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -74,4 +80,12 @@ export class RecipePreviewDto {
   @IsString()
   @IsNotEmpty()
   procedure: string | string[];
+
+  @ApiProperty({
+    description: '레시피 북마크 여부',
+    example: 'true',
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  isFavorite: boolean = false;
 }

--- a/src/recipe/dto/recipePreview.dto.ts
+++ b/src/recipe/dto/recipePreview.dto.ts
@@ -86,6 +86,6 @@ export class RecipePreviewDto {
     example: 'true',
   })
   @IsBoolean()
-  @IsNotEmpty()
-  isFavorite: boolean = false;
+  @IsOptional()
+  isFavorite?: boolean = false;
 }

--- a/src/recipe/recipe.controller.ts
+++ b/src/recipe/recipe.controller.ts
@@ -71,10 +71,11 @@ export class RecipeController {
   @Get('previews')
   @HttpCode(HttpStatus.OK)
   getRecipePreviews(
+    @User() userId: string,
     @Body('recipeIds') recipeIds: number[]
   ): Promise<RecipePreviewDto[]> {
     this.logger.log(`Get recipe previews of ${recipeIds}`);
-    return this.recipeService.getRecipePreviews(recipeIds);
+    return this.recipeService.getRecipePreviews(userId, recipeIds);
   }
 
   //레시피 검색 (난이도, 시간)
@@ -98,24 +99,25 @@ export class RecipeController {
     return this.recipeService.getFilteredRecipe(recipeFilter);
   }
 
-  //상세 레시피
-  @ApiOperation({ summary: '레시피 상세 정보' })
-  @ApiParam({
-    name: 'id',
-    type: Number,
-    required: true,
-    description: '레시피 ID',
-  })
-  @ApiOkResponse({
-    type: RecipeDto,
-    description: '레시피 상세 정보',
-  })
-  @Get('detail/:id')
-  @HttpCode(HttpStatus.OK)
-  getRecipeDetail(@Param('id') recipeId: number): Promise<RecipeDto> {
-    this.logger.log(`Get recipe detail of ${recipeId}`);
-    return this.recipeService.viewRecipeDetails(recipeId);
-  }
+  //TODO: preview와 중복되는 기능, 상의 후 완전 삭제하기
+  // 상세 레시피
+  // @ApiOperation({ summary: '레시피 상세 정보' })
+  // @ApiParam({
+  //   name: 'id',
+  //   type: Number,
+  //   required: true,
+  //   description: '레시피 ID',
+  // })
+  // @ApiOkResponse({
+  //   type: RecipeDto,
+  //   description: '레시피 상세 정보',
+  // })
+  // @Get('detail/:id')
+  // @HttpCode(HttpStatus.OK)
+  // getRecipeDetail(@Param('id') recipeId: number): Promise<RecipeDto> {
+  //   this.logger.log(`Get recipe detail of ${recipeId}`);
+  //   return this.recipeService.viewRecipeDetails(recipeId);
+  // }
 
   //레시피 북마크 추가
   @ApiOperation({ summary: '레시피 북마크 추가' })

--- a/src/recipe/recipe.controller.ts
+++ b/src/recipe/recipe.controller.ts
@@ -105,26 +105,6 @@ export class RecipeController {
     return this.recipeService.getFilteredRecipe(recipeFilter);
   }
 
-  //TODO: preview와 중복되는 기능, 상의 후 완전 삭제하기
-  // 상세 레시피
-  // @ApiOperation({ summary: '레시피 상세 정보' })
-  // @ApiParam({
-  //   name: 'id',
-  //   type: Number,
-  //   required: true,
-  //   description: '레시피 ID',
-  // })
-  // @ApiOkResponse({
-  //   type: RecipeDto,
-  //   description: '레시피 상세 정보',
-  // })
-  // @Get('/detail/:id')
-  // @HttpCode(HttpStatus.OK)
-  // getRecipeDetail(@Param('id') recipeId: number): Promise<RecipeDto> {
-  //   this.logger.log(`Get recipe detail of ${recipeId}`);
-  //   return this.recipeService.viewRecipeDetails(recipeId);
-  // }
-
   @ApiOperation({ summary: '레시피 이름 검색' })
   @ApiQuery({
     name: 'keyword',

--- a/src/recipe/recipe.repository.ts
+++ b/src/recipe/recipe.repository.ts
@@ -132,12 +132,25 @@ export class RecipeRepository {
     return bookmark.recipeId;
   }
 
-  async getBookmark(userId: string): Promise<number[]> {
+  async getBookmark(userId: string): Promise<RecipePreviewDto[]> {
     const bookmarkList = await this.prisma.recipeBookmark.findMany({
       where: { userId },
-      select: { recipeId: true },
+      include: {
+        recipe: {
+          include: {
+            ingredient: {
+              select: {
+                ingredientName: true,
+                amount: true,
+              },
+            },
+          },
+        },
+      },
     });
-    return bookmarkList.map((bookmark) => bookmark.recipeId);
+    return bookmarkList.map((bookmark) => {
+      return { ...bookmark.recipe, isFavorite: true };
+    });
   }
 
   async deleteBookmark(userId: string, recipeId: number): Promise<number> {

--- a/src/recipe/recipe.repository.ts
+++ b/src/recipe/recipe.repository.ts
@@ -96,8 +96,11 @@ export class RecipeRepository {
     });
   }
 
-  async getRecipePreviews(recipeIds: number[]): Promise<RecipePreviewDto[]> {
-    return this.prisma.recipe.findMany({
+  async getRecipePreviews(
+    userId: string,
+    recipeIds: number[]
+  ): Promise<RecipePreviewDto[]> {
+    const previews = await this.prisma.recipe.findMany({
       where: {
         id: { in: recipeIds },
       },
@@ -108,30 +111,20 @@ export class RecipeRepository {
             amount: true,
           },
         },
-      },
-      // select: {
-      //   id: true,
-      //   name: true,
-      //   difficulty: true,
-      //   cookingTime: true,
-      //   imageUrl: true,
-      // },
-    });
-  }
-
-  async getRecipeDetails(recipeId: number): Promise<RecipeDto> {
-    return this.prisma.recipe.findUnique({
-      where: { id: recipeId },
-      include: {
-        ingredient: {
-          select: {
-            ingredientName: true,
-            amount: true,
-          },
+        recipeBookmark: {
+          where: { userId },
+          select: { userId: true },
         },
       },
     });
+    return previews.map((recipe) => {
+      return {
+        ...recipe,
+        isFavorite: recipe.recipeBookmark.length > 0,
+      };
+    });
   }
+
 
   async addBookmark(userId: string, recipeId: number): Promise<number> {
     const bookmark = await this.prisma.recipeBookmark.create({
@@ -140,31 +133,13 @@ export class RecipeRepository {
     return bookmark.recipeId;
   }
 
-  async getBookmark(userId: string): Promise<RecipePreviewDto[]> {
+  async getBookmark(userId: string): Promise<number[]> {
     const bookmarkList = await this.prisma.recipeBookmark.findMany({
       where: { userId },
-      include: {
-        recipe: {
-          include: {
-            ingredient: {
-              select: {
-                ingredientName: true,
-                amount: true,
-              },
-            },
-          },
-          // select: {
-          //   id: true,
-          //   name: true,
-          //   difficulty: true,
-          //   cookingTime: true,
-          //   imageUrl: true,
-          // },
-        },
-      },
-    });
-
-    return bookmarkList.map((bookmark) => bookmark.recipe);
+      select: {recipeId: true}
+      });
+    return bookmarkList.map((bookmark) => bookmark.recipeId);
+    };
   }
 
   async deleteBookmark(userId: string, recipeId: number): Promise<number> {

--- a/src/recipe/recipe.repository.ts
+++ b/src/recipe/recipe.repository.ts
@@ -125,7 +125,6 @@ export class RecipeRepository {
     });
   }
 
-
   async addBookmark(userId: string, recipeId: number): Promise<number> {
     const bookmark = await this.prisma.recipeBookmark.create({
       data: { userId, recipeId },
@@ -136,10 +135,9 @@ export class RecipeRepository {
   async getBookmark(userId: string): Promise<number[]> {
     const bookmarkList = await this.prisma.recipeBookmark.findMany({
       where: { userId },
-      select: {recipeId: true}
-      });
+      select: { recipeId: true },
+    });
     return bookmarkList.map((bookmark) => bookmark.recipeId);
-    };
   }
 
   async deleteBookmark(userId: string, recipeId: number): Promise<number> {

--- a/src/recipe/recipe.service.ts
+++ b/src/recipe/recipe.service.ts
@@ -87,7 +87,7 @@ export class RecipeService {
     const splitSteps = /[0-9]+\.\s/g;
     return previews.map((preview) => {
       if (typeof preview.procedure === 'string') {
-        preview.procedure = preview.procedure.split(splitSteps).slice(1);
+        preview.procedure = preview.procedure.split(splitSteps).slice();
       } else throw new Error('Invalid procedure type');
       return preview;
     });
@@ -120,7 +120,8 @@ export class RecipeService {
   }
 
   async viewMyBookmark(userId: string): Promise<RecipePreviewDto[]> {
-    return this.recipeRepository.getBookmark(userId);
+    const bookmarkRecipes = await this.recipeRepository.getBookmark(userId);
+    return this.processProcedure(bookmarkRecipes);
   }
 
   async deleteBookmark(userId: string, recipeId: number): Promise<number> {

--- a/src/recipe/recipe.service.ts
+++ b/src/recipe/recipe.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { RecipeRepository } from './recipe.repository';
 import { RecipeDto } from './dto/recipe.dto';
-import { ingredientDto } from './dto/ingredient.dto';
 import { RecipePreviewDto } from './dto/recipePreview.dto';
 import { RecipeFilterDto } from './dto/recipeFilter.dto';
 
@@ -56,9 +55,15 @@ export class RecipeService {
    * 프론트에서 레시피ID 리스트를 요청으로 보내면,
    * 해당 레시피들의 프리뷰를 보냄 (id, 이름, 난이도, 조리시간)
    */
-  async getRecipePreviews(recipeIds: number[]): Promise<RecipePreviewDto[]> {
+  async getRecipePreviews(
+    userId: string,
+    recipeIds: number[]
+  ): Promise<RecipePreviewDto[]> {
     if (recipeIds.length === 0) return [];
-    const previews = await this.recipeRepository.getRecipePreviews(recipeIds);
+    const previews = await this.recipeRepository.getRecipePreviews(
+      userId,
+      recipeIds
+    );
     const processed = await this.processProcedure(previews);
 
     return recipeIds.map((id) =>
@@ -96,30 +101,13 @@ export class RecipeService {
     return this.processProcedure(previews);
   }
 
-  /** 레시피 상세정보
-   *
-   * @param recipeId
-   * @returns Recipe Details
-   *
-   * 상세 레시피 정보 반환 (id, 이름, 재료, 상세 설명 등)
-   */
-  async viewRecipeDetails(recipeId: number): Promise<RecipeDto> {
-    const recipeInfo = await this.recipeRepository.getRecipeDetails(recipeId);
-    const splitSteps = /[0-9]+\.\s/g;
-    if (typeof recipeInfo.procedure === 'string')
-      recipeInfo.procedure = recipeInfo.procedure.split(splitSteps).slice(1);
-    else throw new Error('Invalid procedure type');
-    return recipeInfo;
-  }
-
   //북마크 관련 기능
   async addRecipeBookmark(userId: string, recipeId: number): Promise<number> {
     return this.recipeRepository.addBookmark(userId, recipeId);
   }
 
-  async viewMyBookmark(userId: string): Promise<RecipePreviewDto[]> {
-    const previews = await this.recipeRepository.getBookmark(userId);
-    return this.processProcedure(previews);
+  async getMyBookmark(userId: string): Promise<number[]> {
+    return this.recipeRepository.getBookmark(userId);
   }
 
   async deleteBookmark(userId: string, recipeId: number): Promise<number> {

--- a/src/recipe/recipe.service.ts
+++ b/src/recipe/recipe.service.ts
@@ -106,7 +106,7 @@ export class RecipeService {
     return this.recipeRepository.addBookmark(userId, recipeId);
   }
 
-  async getMyBookmark(userId: string): Promise<number[]> {
+  async viewMyBookmark(userId: string): Promise<RecipePreviewDto[]> {
     return this.recipeRepository.getBookmark(userId);
   }
 

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -199,16 +199,4 @@ export class StorageController {
     if (!keyword.trim()) return Promise.resolve([]);
     return this.storageService.searchFoodInfo(keyword);
   }
-
-  @ApiOperation({ summary: '최근 사용한 식재료 가져오기' })
-  @ApiOkResponse({
-    type: FoodDto,
-    isArray: true,
-    description: '최근 사용한 식재료 목록 반환',
-  })
-  @Get('/recent')
-  @HttpCode(HttpStatus.OK)
-  getRecentFoods(@User() userId: string): Promise<FoodDto[]> {
-    return this.storageService.findRecentFoods(userId);
-  }
 }

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -101,8 +101,11 @@ export class StorageRepository {
       take: 10,
       orderBy: { deletedDate: 'desc' },
       where: { userId, deletedDate: { not: null } },
+      distinct: ['name'],
     });
-    return deletedFoods;
+    return deletedFoods.map((food) => {
+      return { ...food, daysTilExpire: null };
+    });
   }
 
   async updateFoodInfo(foodInfo: UpdateFoodDto): Promise<FoodDto> {

--- a/src/storage/storage.repository.ts
+++ b/src/storage/storage.repository.ts
@@ -37,7 +37,7 @@ export class StorageRepository {
     storageType: StorageType
   ): Promise<FoodDto[]> {
     const foodsInStorage = await this.prisma.food.findMany({
-      where: { userId, storageType, deletedDate: null }
+      where: { userId, storageType, deletedDate: null },
     });
     return this.calculateDaysTilExpire(foodsInStorage);
   }
@@ -136,14 +136,5 @@ export class StorageRepository {
       },
       select: { id: true, class1: true, class2: true },
     });
-  }
-
-  async findRecentFoods(userId: string): Promise<FoodDto[]> {
-    const foods = await this.prisma.food.findMany({
-      where: { userId },
-      orderBy: { deletedAt: 'desc' },
-      take: 5,
-    });
-    return this.calculateDaysTilExpire(foods);
   }
 }

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -100,8 +100,4 @@ export class StorageService {
   async searchFoodInfo(keyword: string): Promise<FoodSearchDto[]> {
     return this.storageRepository.searchFoodInfo(keyword);
   }
-
-  async findRecentFoods(userId: string): Promise<FoodDto[]> {
-    return this.storageRepository.findRecentFoods(userId);
-  }
 }


### PR DESCRIPTION
## 변경사항
**최근 사용 식재료 수정**
식재료 이름이 중복되지 않도록 같은 이름을 가질 경우 하나만 반환
daysTilExpire 값을 null로 고정

**RecipePreviewDto에 isFavorite 추가**
레시피 상세정보에 isFavorite 필드를 추가했습니다.
해당 레시피가 북마크된 레시피일 경우 true를 반환합니다.

**기타 변경사항**
레시피 상세 정보를 리턴하는 `recipe/detail/:id` api를 삭제했습니다. (recipe/preview와 중복된 기능)
